### PR TITLE
Add multi-image upload support

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,13 @@ Uploads base64 encoded images to an S3 bucket and creates a database record in `
 - `contact` (string)
 
 This endpoint requires AWS and PostgreSQL credentials via environment variables: `AWS_REGION`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `S3_BUCKET_NAME`, `PGHOST`, `PGUSER`, `PGPASSWORD`, `PGDATABASE` and `PGPORT`.
+
+### `POST /api/uploadImages`
+
+Uploads image files to an S3 bucket and returns their public URLs. The request body must be JSON with an `images` field containing one or more base64 encoded image strings. Only `png`, `jpg`, `jpeg`, `webp` and `avif` images are accepted.
+
+The response will be of the form:
+
+```json
+{ "urls": ["https://..."] }
+```

--- a/api/uploadImages.js
+++ b/api/uploadImages.js
@@ -1,0 +1,63 @@
+const { randomUUID } = require('crypto');
+const AWS = require('aws-sdk');
+
+const s3 = new AWS.S3({
+  region: process.env.AWS_REGION,
+  accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+});
+
+const BUCKET = process.env.S3_BUCKET_NAME;
+
+async function uploadImage(base64) {
+  const matches = base64.match(/^data:(.+);base64,(.+)$/);
+  if (!matches) {
+    throw new Error('Invalid image data');
+  }
+  const contentType = matches[1];
+  const allowed = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/avif'];
+  if (!allowed.includes(contentType)) {
+    throw new Error('Unsupported image format');
+  }
+  const data = Buffer.from(matches[2], 'base64');
+  const key = `${randomUUID()}`;
+  const params = {
+    Bucket: BUCKET,
+    Key: key,
+    Body: data,
+    ContentType: contentType,
+    ACL: 'public-read',
+  };
+  await s3.putObject(params).promise();
+  return `https://${BUCKET}.s3.${process.env.AWS_REGION}.amazonaws.com/${key}`;
+}
+
+module.exports = async (req, res) => {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method Not Allowed' });
+  }
+
+  let body = req.body;
+  if (!body || typeof body === 'string') {
+    try {
+      body = JSON.parse(body || '{}');
+    } catch {
+      return res.status(400).json({ error: 'Invalid JSON body' });
+    }
+  }
+
+  const { images } = body;
+  if (!images) {
+    return res.status(400).json({ error: 'images is required' });
+  }
+
+  const imageArray = Array.isArray(images) ? images : [images];
+  let urls = [];
+  try {
+    urls = await Promise.all(imageArray.map(uploadImage));
+  } catch (err) {
+    return res.status(400).json({ error: err.message });
+  }
+
+  res.status(200).json({ urls });
+};


### PR DESCRIPTION
## Summary
- allow multiple image upload in the register form
- upload selected images to a new `/api/uploadImages` endpoint
- implement `api/uploadImages.js` for S3 uploads
- document the new endpoint

## Testing
- `npm test --silent` *(fails: react-scripts not found)*