### PR TITLE
Fix S3 upload signature mismatch

### DIFF
--- a/api/uploadImages.js
+++ b/api/uploadImages.js
@@ -5,6 +5,7 @@ const s3 = new AWS.S3({
   region: process.env.AWS_REGION,
   accessKeyId: process.env.AWS_ACCESS_KEY_ID,
   secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+  signatureVersion: 'v4',
 });
 
 const BUCKET = process.env.S3_BUCKET_NAME;


### PR DESCRIPTION
## Summary
- ensure S3 client always uses V4 signatures for image uploads

## Testing
- `npm test --silent` *(fails: react-scripts not found)*