### PR TITLE
Align pet type dropdown options

### DIFF
--- a/src/Pets.js
+++ b/src/Pets.js
@@ -1,23 +1,6 @@
 import { useEffect, useState } from 'react';
 import './Pets.css';
-
-const COMMON_PETS = [
-  'Dog',
-  'Cat',
-  'Fish',
-  'Bird',
-  'Hamster',
-  'Guinea Pig',
-  'Rabbit',
-  'Turtle',
-  'Lizard',
-  'Snake',
-  'Frog',
-  'Horse',
-  'Ferret',
-  'Gerbil',
-  'Hermit Crab',
-];
+import { COMMON_PETS } from './petTypes';
 
 export default function Pets() {
   const [pets, setPets] = useState([]);

--- a/src/Register.js
+++ b/src/Register.js
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import './Register.css';
+import { COMMON_PETS } from './petTypes';
 
 export default function Register({ onCancel, onCreated }) {
   const [name, setName] = useState('');
@@ -72,13 +73,18 @@ export default function Register({ onCancel, onCreated }) {
         onChange={(e) => setName(e.target.value)}
         required
       />
-      <input
-        type="text"
-        placeholder="Type"
+      <select
         value={type}
         onChange={(e) => setType(e.target.value)}
         required
-      />
+      >
+        <option value="">Select Type</option>
+        {COMMON_PETS.map((petType) => (
+          <option key={petType} value={petType}>
+            {petType}
+          </option>
+        ))}
+      </select>
       <input
         type="file"
         multiple

--- a/src/petTypes.js
+++ b/src/petTypes.js
@@ -1,0 +1,17 @@
+export const COMMON_PETS = [
+  'Dog',
+  'Cat',
+  'Fish',
+  'Bird',
+  'Hamster',
+  'Guinea Pig',
+  'Rabbit',
+  'Turtle',
+  'Lizard',
+  'Snake',
+  'Frog',
+  'Horse',
+  'Ferret',
+  'Gerbil',
+  'Hermit Crab',
+];


### PR DESCRIPTION
## Summary
- move common pet list to `petTypes.js`
- use shared list in pets filter and register form
- turn register pet type field into a dropdown

## Testing
- `npm test --silent -- --watchAll=false` *(fails: react-scripts not found)*