### PR TITLE
Add translucent background image

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -18,6 +18,22 @@ body {
   background-color: #fff;
 }
 
+body::before {
+  content: "";
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-image: url('/huntfieldbackdrop.jpg');
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+  opacity: 0.1;
+  z-index: -1;
+  pointer-events: none;
+}
+
 a {
   color: var(--color-secondary);
   text-decoration: none;


### PR DESCRIPTION
## Summary
- show `huntfieldbackdrop.jpg` behind all pages with very light opacity

## Testing
- `npm test --silent` *(fails: react-scripts not found)*