### PR TITLE
Improve frontend error handling

### DIFF
--- a/api/petsMiddleware.js
+++ b/api/petsMiddleware.js
@@ -59,7 +59,7 @@ module.exports = async (req, res) => {
   try {
     uploadedUrls = await Promise.all(imageArray.map(uploadImage));
   } catch (err) {
-    return res.status(500).json({ error: 'Failed to upload images' });
+    return res.status(500).json({ error: err.message || 'Failed to upload images' });
   }
 
   const petId = randomUUID();
@@ -70,7 +70,7 @@ module.exports = async (req, res) => {
       [petId, name, type, uploadedUrls, address, contact]
     );
   } catch (err) {
-    return res.status(500).json({ error: 'Database error' });
+    return res.status(500).json({ error: err.message || 'Database error' });
   } finally {
     client.release();
   }

--- a/src/Register.css
+++ b/src/Register.css
@@ -45,3 +45,8 @@
   border-radius: 4px;
   border: 1px solid #ccc;
 }
+
+.error {
+  color: #d9534f;
+  margin: 0;
+}


### PR DESCRIPTION
## Summary
- surface upload/registration errors to users on the Register page
- style error message
- pass underlying error messages from petsMiddleware

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*